### PR TITLE
Fix timeline's hour

### DIFF
--- a/src/utils/transformToScheduleHour.js
+++ b/src/utils/transformToScheduleHour.js
@@ -3,7 +3,7 @@
 const adjustGMT = (hours) => {
   const localTime = hours - 3;
   const withZero = localTime.toString().length === 1 ? `0${localTime}` : localTime;
-  return withZero;
+  return withZero === '00' ? '12' : withZero;
 };
 
 const dateToTime = (date) => {


### PR DESCRIPTION
Fix the format to show the noon time instead of midnight in the timeline, see below:
![image](https://user-images.githubusercontent.com/32140289/125826662-098f585e-bd40-49c2-bacc-3d74c72ce876.png) ![image](https://user-images.githubusercontent.com/32140289/125826553-183b9781-902d-401a-ad46-355570999df3.png)
